### PR TITLE
Fix Payload docs in expr.rs

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -150,24 +150,24 @@ pub struct Range<'a> {
 /// Construct a payload expression, i.e. a reference to a certain part of packet
 /// data.
 pub enum Payload<'a> {
-    /// Creates a raw payload expression to point at a random number of bytes at
-    /// a certain offset from a given reference point.
-    PayloadField(PayloadField<'a>),
     /// Allows one to reference a field by name in a named packet header.
+    PayloadField(PayloadField<'a>),
+    /// Creates a raw payload expression to point at a random number of bits at
+    /// a certain offset from a given reference point.
     PayloadRaw(PayloadRaw),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Creates a raw payload expression to point at a random number
-/// ([len](PayloadRaw::len)) of bytes at a certain offset
+/// ([len](PayloadRaw::len)) of bits at a certain offset
 /// ([offset](PayloadRaw::offset)) from a given reference point
 /// ([base](PayloadRaw::base)).
 pub struct PayloadRaw {
     /// The (protocol layer) reference point.
     pub base: PayloadBase,
-    /// Offset from the reference point.
+    /// Offset from the reference point in bits.
     pub offset: u32,
-    /// Number of bytes.
+    /// Number of bits.
     pub len: u32,
 }
 


### PR DESCRIPTION
Payload offset is in fact given in bits. NFT manual is not very clear in that regard:
>RAW PAYLOAD EXPRESSION
>    @<!-- -->base,offset,length
>The raw payload expression instructs to load length bits starting at offset bits. Bit 0 refers to the very first bit --- in the C programming language, this corresponds to the topmost bit, i.e. 0x80 in case of an octet. They are useful to match headers that do not have a human-readable template expression yet. Note that nft will not add dependencies for Raw payload expressions. If you e.g. want to match protocol fields of a transport header with protocol number 5, you need to manually exclude packets that have a different transport header, for instance by using meta l4proto 5 before the raw expression.
>
>Inner Header / Payload, i.e. after the L4 transport level header
>Matching destination port of both UDP and TCP.
>    inet filter input meta l4proto {tcp, udp} @<!-- -->th,16,16 { 53, 80 }
>The above can also be written as
>    inet filter input meta l4proto {tcp, udp} th dport { 53, 80 }
>

But this:
```
Statement::Match(Match {
        left: Expression::Named(NamedExpression::Payload(Payload::PayloadRaw(PayloadRaw {
            base: PayloadBase::TH,
            offset: 0,
            len: 1,
        }))),
        right: Expression::Number(1),
        op: Operator::EQ,
    });
```
produces an nft rule: `@th,0,8 & 0x80 == 0x80`, checking only the first bit of the transport header. 
Changing the `len` to 8 checks the entire byte: `@th,0,8 0x1`.
